### PR TITLE
Downgrade to Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ A working Java 14 installation is required. In the command line \(terminal in Li
 
 Download the JDK from <https://jdk.java.net/>. On Windows, you can execute `choco install openjdk` (requires [installation of chocolatey - a package manager for Windows](https://chocolatey.org/install)).
 
+Currently, MyLibreLab also works on Java 11.
+You can install it using `apt-get install openjdk-11-jdk` on Debian and Ubuntu linux.
+
 ### IDE Setup
 
 On Windows:

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_14
-    targetCompatibility = JavaVersion.VERSION_14
-
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 compileJava.options.encoding = "cp1252"


### PR DESCRIPTION
The code is not (yet) so modern that we need Java 14.

I thought, I would be a good idea to make installation (from source) for debian users easy. This would also enable easy native packaging of the app for debian.

(See https://packages.debian.org/search?keywords=openjdk for the current available JDKs on debian).

Building an installer still requires JDK14 on the GitHub action.