### PR TITLE
[OLD] Add SonarCloud with gradle.properties

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,64 @@
+name: SonarCloud
+
+on:
+  push:
+    branches:
+      - "*"
+  # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target
+  # We use this event so workflow can be run from the forked repo
+  pull_request_target:
+    types:
+      [
+        assigned,
+        unassigned,
+        labeled,
+        unlabeled,
+        opened,
+        edited,
+        closed,
+        reopened,
+        synchronize,
+        ready_for_review,
+        locked,
+        unlocked,
+        review_requested,
+        review_request_removed,
+        locked,
+        unlocked,
+        review_requested,
+        review_request_removed,
+      ]
+    branches:
+      - "*"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonarqube --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `java-library`
     application
     id("com.github.autostyle")
+    id("org.sonarqube")
     id("com.github.vlsi.gradle-extensions")
     id("org.beryx.runtime")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,15 @@ systemProp.org.gradle.internal.publish.checksums.insecure = true
 # MyLibreLab version
 MyLibreLab.version                                        = 0.1.0
 
+# SonarCloud configuration
+systemProp.sonar.projectKey                               = MyLibreLab_key254582
+systemProp.sonar.organization                             = mylibrelab
+systemProp.sonar.host.url                                 = https://sonarcloud.io
+
 # Plugins
 com.github.vlsi.vlsi-release-plugins.version              = 1.70
 com.github.autostyle.version                              = 3.1
+org.sonarqube.version                                     = 3.0
 org.beryx.runtime.version                                 = 1.8.1
 
 # Dependencies

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ pluginManagement {
         fun PluginDependenciesSpec.idv(id: String, key: String = id) = id(id) version key.v()
 
         idv("com.github.autostyle")
+        idv("org.sonarqube")
         idv("com.github.vlsi.crlf", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.gradle-extensions", "com.github.vlsi.vlsi-release-plugins")
         idv("org.beryx.runtime")


### PR DESCRIPTION
This PR will configure SonarCloud. :tada: 

We integrate Sonar scanner into our gradle build. That is the recommended way of configuring SonarCloud for our codebase.