### PR TITLE
Add SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,36 @@
+name: SonarCloud
+
+on: [push, pull_request_target]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}
+          # Sonar login token with 'Execute Analysis' privileges
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonarqube --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `java-library`
     application
     id("com.github.autostyle")
+    id("org.sonarqube")
     id("com.github.vlsi.gradle-extensions")
     id("org.beryx.runtime")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,15 @@ systemProp.org.gradle.internal.publish.checksums.insecure = true
 # MyLibreLab version
 MyLibreLab.version                                        = 0.1.0
 
+# SonarCloud configuration
+systemProp.sonar.projectKey                               = MyLibreLab_key254582
+systemProp.sonar.organization                             = mylibrelab
+systemProp.sonar.host.url                                 = https://sonarcloud.io
+
 # Plugins
 com.github.vlsi.vlsi-release-plugins.version              = 1.70
 com.github.autostyle.version                              = 3.1
+org.sonarqube.version                                     = 3.0
 org.beryx.runtime.version                                 = 1.8.1
 
 # Dependencies

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ pluginManagement {
         fun PluginDependenciesSpec.idv(id: String, key: String = id) = id(id) version key.v()
 
         idv("com.github.autostyle")
+        idv("org.sonarqube")
         idv("com.github.vlsi.crlf", "com.github.vlsi.vlsi-release-plugins")
         idv("com.github.vlsi.gradle-extensions", "com.github.vlsi.vlsi-release-plugins")
         idv("org.beryx.runtime")


### PR DESCRIPTION
##### This PR will integrate SonarCloud in our action workflows! :tada: 

## Usage

In a typical development process:
1. Developers develop and merge code in an IDE (preferably using SonarLint to receive immediate feedback in the editor) and check-in their code to their ALM.
2. An organization’s continuous integration (CI) tool checks out, builds, and runs unit tests, and an integrated SonarCloud scanner analyzes the results.
3. The scanner posts the results to the SonarCloud server which provides feedback to developers through the SonarCloud interface, email, in-IDE notifications (through SonarLint), and decoration on pull or merge requests (when using Developer Edition and above).

### External Analyzers
Extenrnal analyzers can be integrated into our SonarCloud, supported external analyzers are:

1. PMD
2. SpotBugs
3. CheckStyle

I like both PMD and SpotBugs, but I'm not sure we want this at the moment. We can add SpotBugs because it doesn't report as many violations as PMD.

### Info

1. >With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.
Because of this, we are using [pull_request_target](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target), so our sonar_token can work when we create PR form a fork.
2. Sonar workflow should be run last, so it can collect all the useful data. So for example, after testing, code coverage and other similar tasks. We can configure it in build.gradle like this: `project.tasks["sonarqube"].dependsOn "anotherTask"`


##### Send me an email or DM me on discord for SonarLint token. ^^
