### PR TITLE
Don't upload artifacts to github.

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -57,11 +57,3 @@ jobs:
       - name: Build installer
         run: ./gradlew jpackage -PskipAutostyle -PskipSonarlint
         shell: bash
-      - name: Package application image
-        run: ${{ matrix.archivePortable }} || true
-        shell: bash
-      - name: Upload to GitHub workflow artifacts store
-        uses: actions/upload-artifact@master
-        with:
-          name: MyLibreLab-${{ matrix.displayName }}
-          path: build/distribution


### PR DESCRIPTION
There is no point in uploading the artifact each time the action run. We can add a separate tasks once the application is in a usable state.