### PR TITLE
Implement a service manager to provide annotation based service/provider declarations.

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation("org.jetbrains:annotations")
+    implementation("com.squareup:javapoet")
+    implementation("org.tinylog:tinylog-api")
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/Provider.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/Provider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Classes annotated with this annotation will be automatically detected as a Provider for their
+ * given type bounds.
+ * <p>
+ * Classes annotated with this annotation need to implement {@link ProviderFor} without any free
+ * generic parameters.
+ */
+@ProviderSpec
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface Provider {
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/ProviderFor.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/ProviderFor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations;
+
+/**
+ * A contextual provider.
+ *
+ * @param <T> the type for which this provider provides.
+ * @param <K> the value the provider provides.
+ * @see ProviderSpec
+ */
+public interface ProviderFor<T, K> {
+
+    /**
+     * Get the provided value.
+     *
+     * @param target the target value.
+     * @return the provided value.
+     */
+    K provide(final T target);
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/ProviderForProvider.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/ProviderForProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+import org.tinylog.Logger;
+
+/**
+ * Wrapper class for {@link ProviderFor} classes which ensure an most to least specific sorting when
+ * used.
+ *
+ * @param <T> the input type
+ * @param <K> the output type
+ */
+public abstract class ProviderForProvider<T, K> implements Comparable<ProviderForProvider<?, ?>> {
+
+    private final Class<T> targetType;
+    private final Class<K> valueType;
+
+    public ProviderForProvider(@NotNull final Class<T> targetType, final Class<K> valueType) {
+        this.targetType = targetType;
+        this.valueType = valueType;
+    }
+
+    public boolean canProvide(final Class<?> valueType, final Object target) {
+        return targetType.isInstance(target) && valueType.isAssignableFrom(this.valueType);
+    }
+
+    @Override
+    public int compareTo(@NotNull final ProviderForProvider<?, ?> o) {
+        /*
+         * We want to sort such that the target type is the most specific and the provided type is the least
+         * specific.
+         */
+        int comparison = compare(targetType, o.targetType, o);
+        if (comparison == 0) {
+            return compare(o.valueType, valueType, o);
+        } else {
+            return comparison;
+        }
+    }
+
+    /*
+     * Sort types in ascending order. If the types can't be compared then returns 0.
+     */
+    private int compare(final Class<?> a, final Class<?> b, final ProviderForProvider<?, ?> other) {
+        boolean aGreaterThanB = a.isAssignableFrom(b);
+        boolean bGreaterThanA = b.isAssignableFrom(a);
+        if (aGreaterThanB && bGreaterThanA) return 0;
+        if (aGreaterThanB) return 1;
+        if (bGreaterThanA) return -1;
+        Logger.warn("Both providers '" + this + "' and '" + other + "' qualify for the same service request.\n "
+                + "Choosing the provider with the alphabetically first value type.\n"
+                + "Either make your request more specific or remove one of the given providers.");
+        // To ensure a total order we find the top most types before their nearest common ancestor
+        // and compare their name. This ensures that out of each chain in the class hierarchy poset we
+        // get the top most element before the chains meet.
+        var aCurr = a;
+        var aParent = aCurr;
+        while (!aParent.isAssignableFrom(b)) {
+            aCurr = aParent;
+            aParent = getSuperClass(aCurr);
+        }
+        var bCurr = b;
+        var bParent = bCurr;
+        while (!(bParent.isAssignableFrom(aParent))) {
+            bCurr = bParent;
+            bParent = getSuperClass(bCurr);
+        }
+        return aCurr.getName().compareTo(bCurr.getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProviderForProvider<?, ?> that = (ProviderForProvider<?, ?>) o;
+        return targetType.equals(that.targetType) && valueType.equals(that.valueType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetType, valueType);
+    }
+
+    private static Class<?> getSuperClass(final Class<?> c) {
+        return c.isInterface() ? Object.class : c.getSuperclass();
+    }
+
+    public abstract ProviderFor<T, K> getProvider();
+
+    @Override
+    public String toString() {
+        return "ProviderForProvider{" + "targetType=" + targetType + ", valueType=" + valueType + '}';
+    }
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/ProviderSpec.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/ProviderSpec.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation used to declare new provider annotations which enforce compile time bounds on the
+ * type parameters of {@link ProviderFor}.
+ * <p>
+ * If the newly declared provider annotation needs to be available from a separate module it should
+ * declare it's retention policy as {@code @Retention(RetentionPolicy.CLASS)} otherwise
+ * {@code @Retention(RetentionPolicy.SOURCE)}
+ * <p>
+ * Provider specification are used for service requests where the provided value is dependent on an
+ * object of specific type. Request are handled as follows:
+ * <p>
+ * For an object a of type {@code A} which request an object of type {@code B} a provider which is
+ * "assignable" to {@code ProviderFor<? super A, ? extend B>}.
+ * <p>
+ * "assignable" in quotes because java won't actually let one assign one to the other, but
+ * assignable is meant in the way that the following is legal:
+ *
+ * <pre>
+ * {@code
+ *     ProviderFor<? super A, ? extends B> provider = ...
+ *     A a = ...
+ *     B b = provider.provide(a);
+ * }
+ * </pre>
+ *
+ * If there are multiple candidates which match, then the provider with the most specific inout and
+ * the least specific output type is used. i.e. if there are type {@code C < B < A} (where {@code <}
+ * means "is subtype of"), and {@code P<T, K> := ProviderFor<T, K>} then
+ * <p>
+ * <ul>
+ * <li>requesting {@code P<C, A>} with {@code P<A, A>}, {@code P<B, A>} and {@code P<C, A>}
+ * available will result in {@code P<C, A>} being selected.</li>
+ * <li>requesting {@code P<A, A>} with {@code P<A, A>}, {@code P<A, B>} and {@code P<A, C>}
+ * available will result in {@code P<C, A>} being selected.</li>
+ * </ul>
+ * <p>
+ * If there are multiple providers which fulfill the requested specification which cannot be
+ * compared (e.g. {@code P<A1, B>}, {@code P<A2, B>} where {@code A1} and {@code A2} both are
+ * subtypes of {@code A} but neither is a subtype of the other) then a warning is issued and no
+ * guarantee is given on which provider will be used.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface ProviderSpec {
+
+    /**
+     * The bound for the input type. This is a contravariant bound. i.e. if the bound is of type B and A
+     * is a supertype of B then A will be an accepted type.
+     *
+     * This value can't be a primitive type.
+     *
+     * The default value is {@code void.class}. This value is arbitrarily chosen as there is no bottom
+     * type in java. However primitives types aren't allowed.
+     *
+     * @return the bound for the input type.
+     */
+    Class<?> inputBound() default void.class;
+
+    /**
+     * The bound for the input type. This is a covariant bound. i.e. if the bound is of type A and B is
+     * a subtype of A then B will be an accepted type.
+     *
+     * This value can't be a primitive type.
+     *
+     * The default value is {@code Object.class} as it's the top type.
+     *
+     * @return the bound for the output type.
+     */
+    Class<?> outputBound() default Object.class;
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/Service.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/Service.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Service {
+    Class<?> value();
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/ServiceSpec.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/ServiceSpec.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface ServiceSpec {
+    Class<?> value();
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/processor/ProcessorBase.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/processor/ProcessorBase.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations.processor;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Target;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.lang.model.element.*;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
+
+public abstract class ProcessorBase extends AbstractProcessor {
+
+    protected boolean verifyMetaAnnotatedElement(final Element element) {
+        if (element.getAnnotation(Inherited.class) != null) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "cannot be @Inherited");
+            return false;
+        }
+        Target target = element.getAnnotation(Target.class);
+        if (target == null) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "must be marked with @Target");
+            return false;
+        }
+        if (target.value().length == 0) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                    "must have at least one element type in @Target");
+            return false;
+        }
+        for (ElementType type : target.value()) {
+            if (type != ElementType.TYPE) {
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                        "should not be permitted on element type " + type);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected boolean isVoid(final TypeMirror typeMirror) {
+        var voidMirror = processingEnv.getTypeUtils().getNoType(TypeKind.VOID);
+        return processingEnv.getTypeUtils().isSameType(voidMirror, typeMirror);
+    }
+
+    protected AnnotationValue[] getAnnotationValues(final AnnotationMirror annotation, final String... names) {
+        Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues =
+                annotation != null ? annotation.getElementValues() : Collections.emptyMap();
+        var values = new AnnotationValue[names.length];
+        for (var entry : elementValues.entrySet()) {
+            var name = entry.getKey().getSimpleName().toString();
+            for (int i = 0; i < names.length; i++) {
+                if (names[i].equals(name)) {
+                    values[i] = entry.getValue();
+                }
+            }
+        }
+        return values;
+    }
+
+    protected <T> TypeElement getTypeElement(final Class<T> classType) {
+        return processingEnv.getElementUtils().getTypeElement(classType.getName());
+    }
+
+    protected <T> TypeMirror getTypeMirror(final Class<T> classType) {
+        return getTypeElement(classType).asType();
+    }
+
+    protected TypeElement asTypeElement(final TypeMirror typeMirror) {
+        return (TypeElement) processingEnv.getTypeUtils().asElement(typeMirror);
+    }
+
+    protected AnnotationMirror getAnnotationMirror(final TypeElement element, final TypeMirror annotationType) {
+        return element
+                .getAnnotationMirrors().stream().filter(mir -> processingEnv.getTypeUtils()
+                        .isSameType(mir.getAnnotationType().asElement().asType(), annotationType))
+                .findFirst().orElse(null);
+    }
+
+    protected void info(final String info) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, info + "\r\n");
+    }
+
+    protected void error(final String error, final Element e, final AnnotationMirror a, final AnnotationValue v) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error + "\r\n", e, a, v);
+    }
+
+    protected void error(final String error, final Element e, final AnnotationMirror a) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error + "\r\n", e, a);
+    }
+
+    protected void error(final String error, final Element e) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error + "\r\n", e);
+    }
+
+    protected void error(final String error) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error + "\r\n");
+    }
+
+    protected void error(final Exception e) {
+        var out = new ByteArrayOutputStream();
+        e.printStackTrace(new PrintWriter(out));
+        error(e.toString() + "\r\n" + out.toString(StandardCharsets.UTF_8));
+    }
+
+    protected void warning(final String warning, final Element e, final AnnotationMirror a, final AnnotationValue v) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, warning + "\r\n", e, a, v);
+    }
+
+    protected void warning(final String warning, final Element e, final AnnotationMirror a) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, warning + "\r\n", e, a);
+    }
+
+    protected void warning(final String warning, final Element e) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, warning + "\r\n", e);
+    }
+
+    protected void warning(final String warning) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, warning + "\r\n");
+    }
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/processor/ProviderProcessor.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/processor/ProviderProcessor.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations.processor;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.*;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+
+import com.github.mylibrelab.annotations.ProviderFor;
+import com.github.mylibrelab.annotations.ProviderForProvider;
+import com.github.mylibrelab.annotations.ProviderSpec;
+import com.github.mylibrelab.annotations.Service;
+import com.squareup.javapoet.*;
+
+
+@SupportedAnnotationTypes("*")
+public class ProviderProcessor extends ProcessorBase {
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+        try {
+            Collection<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(ProviderSpec.class);
+            var annotatedTypeElements = ElementFilter.typesIn(annotatedElements);
+            var providerSpecMirror = getTypeMirror(ProviderSpec.class);
+            for (var providerAnnotationDefinition : annotatedTypeElements) {
+                if (!verifyMetaAnnotatedElement(providerAnnotationDefinition)) return false;
+                var providerSpec = providerAnnotationDefinition.getAnnotation(ProviderSpec.class);
+                var mirror = getAnnotationMirror(providerAnnotationDefinition, providerSpecMirror);
+                if (!checkProviderSpec(providerSpec, providerAnnotationDefinition, mirror)) return false;
+            }
+            for (var annotation : annotations) {
+                var providerSpec = annotation.getAnnotation(ProviderSpec.class);
+                if (providerSpec != null) {
+                    info("Processing provider annotation " + annotation);
+                    processAnnotation(roundEnv, annotation, providerSpec);
+                }
+            }
+        } catch (Exception e) {
+            // Don't propagate any exceptions to the compiler
+            error(e);
+        }
+        return false;
+    }
+
+    private boolean checkProviderSpec(final ProviderSpec providerSpec, final TypeElement element,
+            final AnnotationMirror annotation) {
+        var values = getAnnotationValues(annotation, "inputBound", "outputBound");
+        return checkType(getBound(providerSpec, ProviderSpec::inputBound), true, element, annotation, values[0])
+                && checkType(getBound(providerSpec, ProviderSpec::outputBound), false, element, annotation, values[1]);
+    }
+
+    private TypeMirror getBound(final ProviderSpec providerSpec, final Function<ProviderSpec, Class<?>> getter) {
+        try {
+            return processingEnv.getElementUtils().getTypeElement(getter.apply(providerSpec).getName()).asType();
+        } catch (MirroredTypeException mte) {
+            return mte.getTypeMirror();
+        }
+    }
+
+    private boolean checkType(final TypeMirror typeMirror, final boolean allowVoid, final TypeElement element,
+            final AnnotationMirror annotation, final AnnotationValue value) {
+        boolean violated;
+        if (allowVoid) {
+            violated = !isVoid(typeMirror) && typeMirror.getKind().isPrimitive();
+        } else {
+            violated = typeMirror.getKind().isPrimitive();
+        }
+        if (violated) {
+            error("Primitive type " + typeMirror + " is not allowed.", element, annotation, value);
+            return false;
+        }
+        return true;
+    }
+
+    private void processAnnotation(final RoundEnvironment roundEnv, final TypeElement annotation,
+            final ProviderSpec providerSpec) {
+        Collection<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
+        List<TypeElement> types = ElementFilter.typesIn(annotatedElements);
+        processAnnotation(types, providerSpec);
+    }
+
+    private void processAnnotation(final List<TypeElement> types, final ProviderSpec providerSpec) {
+        for (TypeElement typeElement : types) {
+            info("Processing element " + typeElement);
+            processElement(typeElement, providerSpec);
+        }
+    }
+
+    private void processElement(final TypeElement typeElement, final ProviderSpec providerSpec) {
+        var typeUtils = processingEnv.getTypeUtils();
+
+        TypeMirror providerForType = typeUtils.erasure(getTypeMirror(ProviderFor.class));
+        Predicate<TypeMirror> providerFilter = tm -> typeUtils.isSameType(typeUtils.erasure(tm), providerForType);
+
+        findInterface(typeElement.asType(), providerFilter).ifPresentOrElse(declaredType -> {
+            var typeArguments = declaredType.getTypeArguments();
+            TypeMirror receiverType = typeArguments.get(0);
+            TypeMirror returnType = typeArguments.get(1);
+            if (!checkTypeBounds(receiverType, returnType, providerSpec, typeElement)) {
+                return;
+            }
+
+            TypeElement erasedSuperType = getTypeElement(ProviderForProvider.class);
+            createProviderClass(typeElement, receiverType, returnType, erasedSuperType);
+        }, () -> error("Provider needs to implement ProviderFor.", typeElement));
+    }
+
+    private boolean checkTypeBounds(final TypeMirror receiverType, final TypeMirror returnType,
+            final ProviderSpec providerSpec, final TypeElement typeElement) {
+        if (providerSpec == null) return true;
+        var typeUtils = processingEnv.getTypeUtils();
+        TypeMirror inputBoundType = getBound(providerSpec, ProviderSpec::inputBound);
+        if (!typeUtils.isSameType(inputBoundType, typeUtils.getNoType(TypeKind.VOID))
+                && !typeUtils.isAssignable(inputBoundType, receiverType)) {
+            error("Type " + receiverType + " can't be assigned from input bound " + inputBoundType, typeElement);
+            return false;
+        }
+        TypeMirror outputTypeBounds = getBound(providerSpec, ProviderSpec::outputBound);
+        // Object is the top type thus any type trivially is accepted.
+        if (!typeUtils.isSameType(outputTypeBounds, getTypeMirror(Object.class))
+                && !typeUtils.isAssignable(returnType, outputTypeBounds)) {
+            error("Type " + returnType + " can't be assigned to output bound " + outputTypeBounds, typeElement);
+            return false;
+        }
+        return true;
+    }
+
+    private void createProviderClass(final TypeElement typeElement, final TypeMirror receiverType,
+            final TypeMirror returnType, final TypeElement erasedSuperType) {
+
+        var typeUtils = processingEnv.getTypeUtils();
+        var elementUtils = processingEnv.getElementUtils();
+
+        FieldSpec providerField =
+                FieldSpec.builder(TypeName.get(typeElement.asType()), "provider", Modifier.PRIVATE).build();
+
+        MethodSpec getProviderMethod =
+                MethodSpec.methodBuilder("getProvider").addAnnotation(Override.class).addModifiers(Modifier.PUBLIC)
+                        .returns(ParameterizedTypeName.get(ClassName.get(ProviderFor.class), TypeName.get(receiverType),
+                                TypeName.get(returnType)))
+                        .beginControlFlow("if (provider == null)").addStatement("provider = new $T()", typeElement)
+                        .endControlFlow().addStatement("return provider").build();
+
+        MethodSpec constructor = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC)
+                .addStatement("super($T.class, $T.class)", receiverType, returnType).build();
+
+        AnnotationSpec service =
+                AnnotationSpec.builder(Service.class).addMember("value", "$T.class", ProviderForProvider.class).build();
+
+        var providerTypeName = typeElement.getQualifiedName().toString().replace(".", "_") + "Provider";
+        var packageName = elementUtils.getPackageOf(typeElement).getQualifiedName().toString();
+
+        TypeSpec providerForProvider = TypeSpec.classBuilder(providerTypeName)
+                .superclass(typeUtils.getDeclaredType(erasedSuperType, receiverType, returnType)).addAnnotation(service)
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL).addMethod(constructor).addField(providerField)
+                .addMethod(getProviderMethod).addOriginatingElement(typeElement).build();
+
+        JavaFile file = JavaFile.builder(packageName, providerForProvider).build();
+
+        try {
+            file.writeTo(processingEnv.getFiler());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Optional<DeclaredType> findInterface(final TypeMirror typeMirror, final Predicate<TypeMirror> predicate) {
+        if (predicate.test(typeMirror)) {
+            return Optional.of((DeclaredType) typeMirror);
+        }
+        for (var interfaceElement : processingEnv.getTypeUtils().directSupertypes(typeMirror)) {
+            var optTypeMirror = findInterface(interfaceElement, predicate);
+            if (optTypeMirror.isPresent()) {
+                return optTypeMirror;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/annotations/src/main/java/com/github/mylibrelab/annotations/processor/ServiceProcessor.java
+++ b/annotations/src/main/java/com/github/mylibrelab/annotations/processor/ServiceProcessor.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.annotations.processor;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.tools.StandardLocation;
+
+import com.github.mylibrelab.annotations.Service;
+import com.github.mylibrelab.annotations.ServiceSpec;
+
+@SupportedAnnotationTypes("*")
+public class ServiceProcessor extends ProcessorBase {
+
+    private static final boolean DEBUG = false;
+    public static final String SERVICE_DEFS_FOLDER = "META-INF/serviceDefs/";
+    public static final String SERVICES_FOLDER = "META-INF/services/";
+
+    TypeElement dummyElement;
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+        try {
+            processPlainServices(roundEnv);
+            if (!checkServiceSpecs(roundEnv)) {
+                return false;
+            }
+            processAnnotations(annotations, roundEnv);
+            if (roundEnv.processingOver()) {
+                generateConfigFiles();
+            }
+        } catch (Exception e) {
+            // Don't propagate any exceptions to the compiler
+            error(e);
+        }
+        return false;
+    }
+
+    private void processAnnotations(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+        for (var annotation : annotations) {
+            var serviceSpec = annotation.getAnnotation(ServiceSpec.class);
+            if (serviceSpec != null) {
+                info("Processing service annotation " + annotation);
+                processServiceAnnotation(roundEnv, annotation, getServiceInterface(serviceSpec));
+            }
+        }
+    }
+
+    private void processServiceAnnotation(final RoundEnvironment roundEnv, final TypeElement annotation,
+            final TypeMirror serviceType) {
+        Collection<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotation);
+        List<TypeElement> elements = ElementFilter.typesIn(annotatedElements);
+        if (!elements.isEmpty()) {
+            info("Processing " + elements.size() + " elements annotated with " + annotation.getSimpleName());
+            for (var element : elements) {
+                if (dummyElement == null) dummyElement = element;
+                processElement(element, serviceType);
+            }
+        }
+    }
+
+    private void processPlainServices(final RoundEnvironment roundEnv) {
+        Collection<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(Service.class);
+        var elements = ElementFilter.typesIn(annotatedElements);
+        if (!elements.isEmpty()) {
+            info("Processing " + elements.size() + " elements annotated with " + Service.class.getSimpleName());
+            for (var element : elements) {
+                var service = element.getAnnotation(Service.class);
+                var serviceInterface = getServiceInterface(service);
+                if (serviceInterface.getKind().isPrimitive()) {
+                    var annotationMirror =
+                            getAnnotationMirror(asTypeElement(serviceInterface), getTypeMirror(Service.class));
+                    error("Primitive type '" + serviceInterface + "' not allowed.", element, annotationMirror,
+                            getAnnotationValues(annotationMirror, "value")[0]);
+                    continue;
+                }
+                processElement(element, serviceInterface);
+            }
+        }
+    }
+
+    private void processElement(final TypeElement element, final TypeMirror serviceType) {
+        var typeUtils = processingEnv.getTypeUtils();
+        if (!typeUtils.isAssignable(element.asType(), serviceType)) {
+            error(element + " needs to be of type " + serviceType, element);
+            return;
+        }
+        var interfaceName = getBinaryName(asTypeElement(serviceType));
+        var implementationName = getBinaryName(element);
+        try {
+            var path = getServiceDefsPath(interfaceName, implementationName);
+            if (DEBUG) info("Creating " + path);
+            var file = processingEnv.getFiler().createResource(StandardLocation.SOURCE_OUTPUT, "", path, element);
+            var outStream = file.openOutputStream();
+            try (var write = new BufferedWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8))) {
+                write.write(implementationName);
+            }
+            outStream.close();
+        } catch (IOException e) {
+            error(e);
+        }
+    }
+
+    private String getServiceDefsPath(final String folderName, final String fileName) {
+        return SERVICE_DEFS_FOLDER + folderName + "/" + fileName;
+    }
+
+    private void generateConfigFiles() {
+        var serviceDefPath = getServiceDefPath();
+        if (serviceDefPath != null) {
+            try (var files = Files.list(serviceDefPath)) {
+                files.filter(Files::isDirectory).forEach(d -> {
+                    var serviceName = d.getFileName().toString();
+                    try (var serviceImpls = Files.list(d)) {
+                        var content = serviceImpls.map(Path::getFileName).map(Objects::toString)
+                                .collect(Collectors.joining("\n"));
+                        writeServiceFile(serviceName, content);
+                    } catch (IOException e) {
+                        error(e);
+                    }
+                });
+            } catch (IOException e) {
+                error(e);
+            }
+        }
+    }
+
+    private void writeServiceFile(final String service, final String content) throws IOException {
+        var serviceName = SERVICES_FOLDER + service;
+        try {
+            if (DEBUG) info("Checking " + serviceName);
+            var file = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", serviceName);
+            var inStr = file.openInputStream();
+            inStr.close();
+            file.delete();
+        } catch (IOException ignored) {
+            // The file doesn't exist thus doesn't need to be deleted.
+        }
+        info("Writing Service file " + serviceName);
+        var file =
+                processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", serviceName, dummyElement);
+        var outStream = file.openOutputStream();
+        try (var write = new BufferedWriter(new OutputStreamWriter(outStream, StandardCharsets.UTF_8))) {
+            write.write(content);
+        }
+        outStream.close();
+    }
+
+    private Path getServiceDefPath() {
+        var filer = processingEnv.getFiler();
+        try {
+            var resource = filer.getResource(StandardLocation.SOURCE_OUTPUT, "", SERVICE_DEFS_FOLDER + "tmp");
+            Path path = Paths.get(resource.toUri()).getParent();
+            resource.delete();
+            return path;
+        } catch (IOException e) {
+            error(e);
+        }
+        return null;
+    }
+
+    private TypeMirror getServiceInterface(final Service service) {
+        try {
+            return processingEnv.getElementUtils().getTypeElement(service.value().getName()).asType();
+        } catch (MirroredTypeException mte) {
+            return mte.getTypeMirror();
+        }
+    }
+
+    private TypeMirror getServiceInterface(final ServiceSpec service) {
+        try {
+            return processingEnv.getElementUtils().getTypeElement(service.value().getName()).asType();
+        } catch (MirroredTypeException mte) {
+            return mte.getTypeMirror();
+        }
+    }
+
+    private boolean checkServiceSpecs(final RoundEnvironment roundEnv) {
+        Collection<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(ServiceSpec.class);
+        var annotatedTypeElements = ElementFilter.typesIn(annotatedElements);
+        for (var serviceAnnotationDefinition : annotatedTypeElements) {
+            if (!verifyMetaAnnotatedElement(serviceAnnotationDefinition)) return false;
+        }
+        return true;
+    }
+
+    private String getBinaryName(TypeElement element) {
+        return getBinaryNameImpl(element, element.getSimpleName().toString());
+    }
+
+    private String getBinaryNameImpl(TypeElement element, String className) {
+        Element enclosingElement = element.getEnclosingElement();
+
+        if (enclosingElement instanceof PackageElement) {
+            PackageElement pkg = (PackageElement) enclosingElement;
+            if (pkg.isUnnamed()) {
+                return className;
+            }
+            return pkg.getQualifiedName() + "." + className;
+        }
+
+        TypeElement typeElement = (TypeElement) enclosingElement;
+        return getBinaryNameImpl(typeElement, typeElement.getSimpleName() + "$" + className);
+    }
+}

--- a/annotations/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/annotations/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,2 @@
+com.github.mylibrelab.annotations.processor.ProviderProcessor,ISOLATING
+com.github.mylibrelab.annotations.processor.ServiceProcessor,ISOLATING

--- a/annotations/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/annotations/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,2 @@
+com.github.mylibrelab.annotations.processor.ProviderProcessor
+com.github.mylibrelab.annotations.processor.ServiceProcessor

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import com.github.vlsi.gradle.crlf.CrLfSpec
 import com.github.vlsi.gradle.crlf.LineEndings
 import com.github.vlsi.gradle.properties.dsl.props
 import name.remal.gradle_plugins.plugins.code_quality.sonar.SonarLintExtension
+import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -157,7 +158,7 @@ allprojects {
                 // Ignore [Inheritance tree of classes should not be too deep]
                 // Extending JComponent will break this rule.
                 message("java:S110")
-                // Some classes benefit from mmore descriptive generic type paramaters.
+                // Some classes benefit from more descriptive generic type parameters.
                 message("java:S119")
             }
         }
@@ -205,6 +206,7 @@ allprojects {
                 java {
                     importOrder("java", "javax", "org", "com", "")
                     removeUnusedImports()
+
                     eclipse {
                         configFile("${project.rootDir}/config/style.eclipseformat.xml")
                     }
@@ -227,8 +229,14 @@ allprojects {
             val bom = platform(project(":mylibrelab-dependencies-bom"))
             "api"(bom)
             "annotationProcessor"(bom)
-            "kapt"(bom)
         }
+    }
+
+    extensions.findByType(KaptExtension::class)?.run {
+        dependencies {
+            "kapt"(platform(project(":mylibrelab-dependencies-bom")))
+        }
+        includeCompileClasspath = false
     }
 
     tasks.withType<KotlinCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ val skipSonarlint by props()
 
 dependencies {
     implementation(project(":mylibrelab-settings-api"))
+    implementation(project(":mylibrelab-service-manager"))
     implementation(project(":mylibrelab-util"))
 
     implementation("org.json:json")
@@ -51,8 +52,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     implementation(kotlin("stdlib"))
-    kapt("com.google.auto.service:auto-service")
-    compileOnly("com.google.auto.service:auto-service-annotations")
+    kapt(project(":mylibrelab-annotations"))
 
     /* Currently unused dependencies. Those need further investigation whether they are needed for the elements
      * at runtime.

--- a/dependencies-bom/build.gradle.kts
+++ b/dependencies-bom/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
         // runtime means "the dependency is only for runtime, not for compilation"
         // In other words, marking dependency as "runtime" would avoid accidental
         // dependency on it during compilation
+        apiv("org.jetbrains:annotations", "jetbrains.annotations")
         apiv("com.google.guava:guava")
         apiv("javax.vecmath:vecmath")
         apiv("eu.hansolo:SteelSeries")
@@ -61,5 +62,6 @@ dependencies {
 
         apiv("com.google.auto.service:auto-service-annotations", "auto-service")
         apiv("com.google.auto.service:auto-service", "auto-service")
+        apiv("com.squareup:javapoet")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # suppress inspection "UnusedProperty" for whole file
 org.gradle.parallel                                       = true
 kotlin.code.style                                         = official
+kapt.incremental.apt                                      = true
 
 # See https://github.com/gradle/gradle/pull/11358 , https://issues.apache.org/jira/browse/INFRA-14923
 # repository.apache.org does not yet support .sha256 and .sha512 checksums
@@ -40,3 +41,5 @@ darklaf.version                                           = latest.integration
 findbugs.version                                          = 3.0.2
 junit.version                                             = 5.6.0
 auto-service.version                                      = 1.0-rc7
+jetbrains.annotations.version                             = 16.0.1
+javapoet.version                                          = 1.13.0

--- a/service-manager/build.gradle.kts
+++ b/service-manager/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":mylibrelab-annotations"))
+    implementation("org.tinylog:tinylog-api")
+    implementation("org.jetbrains:annotations")
+}

--- a/service-manager/src/main/java/com/github/mylibrelab/service/ServiceManager.java
+++ b/service-manager/src/main/java/com/github/mylibrelab/service/ServiceManager.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2020 MyLibreLab
+ * Based on MyOpenLab by Carmelo Salafia www.myopenlab.de
+ * Copyright (C) 2004  Carmelo Salafia cswi@gmx.de
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.github.mylibrelab.service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.tinylog.Logger;
+
+import com.github.mylibrelab.annotations.ProviderForProvider;
+
+/**
+ * Utility class to handle service loading.
+ */
+public class ServiceManager {
+
+    private static final List<ProviderForProvider<Object, Object>> providerList;
+    private static final Map<Class<?>, Map<Object, Object>> contextualServiceCache = new HashMap<>();
+    private static final Map<Class<?>, ServiceLoader<?>> serviceLoaderMap = new HashMap<>();
+
+    static {
+        // noinspection unchecked
+        providerList = ServiceLoader.load(ProviderForProvider.class).stream().map(ServiceLoader.Provider::get)
+                .map(p -> (ProviderForProvider<Object, Object>) p).collect(Collectors.toList());
+    }
+
+    private ServiceManager() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Returns a service which is constructed from the given target value.
+     * <p>
+     * Providers can be registered with the {@link com.github.mylibrelab.annotations.Provider}
+     * annotation or any other annotation which is annotated with
+     * {@link com.github.mylibrelab.annotations.ProviderSpec}.
+     * <p>
+     * Providers need to implement {@link com.github.mylibrelab.annotations.ProviderFor} with the
+     * fitting type bounds.
+     * <p>
+     * Request are handled as follows:
+     * <p>
+     * For an object a of type {@code A} which request an object of type {@code B} a provider which is
+     * "assignable" to {@code ProviderFor<? super A, ? extend B>}.
+     * <p>
+     * "assignable" in quotes because java won't actually let one assign one to the other, but
+     * assignable is meant in the way that the following is legal:
+     *
+     * <pre>
+     * {@code
+     *     ProviderFor<? super A, ? extends B> provider = ...
+     *     A a = ...
+     *     B b = provider.provide(a);
+     * }
+     * </pre>
+     *
+     * If there are multiple candidates which match, then the provider with the most specific inout and
+     * the least specific output type is used. i.e. if there are type {@code C < B < A} (where {@code <}
+     * means "is subtype of"), and {@code P<T, K> := ProviderFor<T, K>} then
+     * <p>
+     * <ul>
+     * <li>requesting {@code P<C, A>} with {@code P<A, A>}, {@code P<B, A>} and {@code P<C, A>}
+     * available will result in {@code P<C, A>} being selected.</li>
+     * <li>requesting {@code P<A, A>} with {@code P<A, A>}, {@code P<A, B>} and {@code P<A, C>}
+     * available will result in {@code P<C, A>} being selected.</li>
+     * </ul>
+     * <p>
+     * If there are multiple providers which fulfill the requested specification which cannot be
+     * compared (e.g. {@code P<A1, B>}, {@code P<A2, B>} where {@code A1} and {@code A2} both are
+     * subtypes of {@code A} but neither is a subtype of the other) then a warning is issued and no
+     * guarantee is given on which provider will be used.
+     *
+     * @param type the class of the requested value.
+     * @param target the target value.
+     * @param <T> the type of the requested value.
+     * @return the provided value.
+     */
+    @NotNull
+    public static <T> T getProvidedServiceFor(@NotNull final Class<T> type, final Object target) {
+        var map = contextualServiceCache.get(type);
+        if (map != null) {
+            var provided = map.get(target);
+            if (type.isInstance(provided)) {
+                return type.cast(provided);
+            }
+        }
+        var provider = providerList.stream().filter(p -> p.canProvide(type, target)).sorted().findFirst()
+                .orElseThrow(IllegalStateException::new);
+        var providedValue = provider.getProvider().provide(target);
+        contextualServiceCache.computeIfAbsent(type, t -> new WeakHashMap<>()).put(target, providedValue);
+        T service = type.cast(providedValue);
+        if (service == null) {
+            throw new IllegalStateException(
+                    "No provider with return type " + type + " for target " + target + " was found");
+        }
+        return service;
+    }
+
+    /**
+     * Returns all registered services for the given type.
+     * <p>
+     * Services can be registered using the {@link com.github.mylibrelab.annotations.Service @Service}
+     * annotation or any other annotation which is annotated by
+     * {@link com.github.mylibrelab.annotations.ServiceSpec @Service}.
+     *
+     * @param type the class of the service.
+     * @param <T> the service type.
+     * @return all registered services.
+     */
+    @NotNull
+    @SuppressWarnings("unchecked")
+    public static <T> Iterable<T> getAllServices(@NotNull final Class<T> type) {
+        return (Iterable<T>) serviceLoaderMap.computeIfAbsent(type, ServiceLoader::load);
+    }
+
+    /**
+     * Returns the service for the given type.
+     *
+     * @param type the service class.
+     * @param <T> the service type
+     * @return the registered service. If there are more than one registered services one is chosen and
+     *         a warning is issued.
+     */
+    @NotNull
+    public static <T> T getService(@NotNull final Class<T> type) {
+        var sl = getAllServices(type).iterator();
+        T service = sl.next();
+        if (sl.hasNext()) {
+            Logger.warn("Service type '" + type
+                    + "' has multiple implementation but is requested as a single service. Provided implementation is non deterministic.");
+        }
+        return service;
+    }
+
+    /**
+     * Returns the service for the given type if it already has been created.
+     *
+     * @param type the service type.
+     * @param <T> the service type.
+     * @return the registered service. If there are more than one registered services one is chosen and
+     *         a warning is issued.
+     * @see #getService(Class)
+     */
+    @Nullable
+    public static <T> T getServiceIfCreated(@NotNull final Class<T> type) {
+        if (serviceLoaderMap.containsKey(type)) {
+            return getService(type);
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/settings-api/build.gradle.kts
+++ b/settings-api/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
+    compileOnly(project(":mylibrelab-annotations"))
+    implementation(project(":mylibrelab-service-manager"))
     implementation(project(":mylibrelab-util"))
+
+    implementation(kotlin("stdlib"))
+    implementation("org.tinylog:tinylog-api")
 }

--- a/settings-api/src/main/kotlin/com/github/mylibrelab/settings/api/SettingsProvider.kt
+++ b/settings-api/src/main/kotlin/com/github/mylibrelab/settings/api/SettingsProvider.kt
@@ -18,16 +18,11 @@
  *
  */
 
-package com.github.mylibrelab.ui.component.dummy;
+package com.github.mylibrelab.settings.api
 
-import com.github.mylibrelab.annotations.Service;
-import com.github.mylibrelab.ui.component.AppComponent;
-import com.github.weisj.darklaf.util.Alignment;
+import com.github.mylibrelab.annotations.ServiceSpec
 
-@Service(AppComponent.class)
-public class DummyB extends DummyComponent {
-
-    public DummyB() {
-        super("Dummy B", null, Alignment.NORTH_EAST);
-    }
-}
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+@ServiceSpec(SettingsContainerProvider::class)
+annotation class SettingsProvider

--- a/settings-api/src/main/kotlin/com/github/mylibrelab/settings/api/SettingsStorage.kt
+++ b/settings-api/src/main/kotlin/com/github/mylibrelab/settings/api/SettingsStorage.kt
@@ -20,9 +20,8 @@
 
 package com.github.mylibrelab.settings.api
 
-import java.util.*
+import com.github.mylibrelab.service.ServiceManager
 import java.util.prefs.Preferences
-import kotlin.collections.HashMap
 
 object SettingsStorage {
 
@@ -35,7 +34,7 @@ object SettingsStorage {
     @Volatile
     private var saving: Boolean = false
     val containers: List<SettingsContainer> =
-        ServiceLoader.load(SettingsContainerProvider::class.java)
+        ServiceManager.getAllServices(SettingsContainerProvider::class.java)
             .asSequence()
             .filter { it.enabled }
             .map { it.create() }
@@ -63,7 +62,7 @@ object SettingsStorage {
         ).forEach { (identifier, propertyList) ->
             preferencesRoot.node(identifier).addPreferenceChangeListener {
                 if (saving) return@addPreferenceChangeListener
-                propertyList.map { it.container }.forEach { container ->
+                propertyList.asSequence().map { it.container }.distinct().forEach { container ->
                     loadSettings(container)
                 }
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,8 +18,10 @@ pluginManagement {
 rootProject.name = "MyLibreLab"
 
 include(
+    "annotations",
     "dependencies-bom",
     "settings-api",
+    "service-manager",
     "util"
 )
 

--- a/src/main/java/com/github/mylibrelab/lifecycle/AppLifecycleManager.java
+++ b/src/main/java/com/github/mylibrelab/lifecycle/AppLifecycleManager.java
@@ -20,13 +20,12 @@
 
 package com.github.mylibrelab.lifecycle;
 
-import java.util.ServiceLoader;
-
 import org.jetbrains.annotations.NotNull;
 
 import com.github.mylibrelab.event.EventBus;
 import com.github.mylibrelab.event.Topic;
 import com.github.mylibrelab.event.Topics;
+import com.github.mylibrelab.service.ServiceManager;
 
 /**
  * Dispatcher to notify {@link AppLifecycleListener} about various stages of the application
@@ -66,7 +65,7 @@ public enum AppLifecycleManager {
 
     AppLifecycleManager() {
         eventBus = EventBus.get(Topics.APP_LIFECYCLE);
-        ServiceLoader.load(AppLifecycleListener.class).forEach(eventBus::subscribe);
+        ServiceManager.getAllServices(AppLifecycleListener.class).forEach(eventBus::subscribe);
     }
 
     /**

--- a/src/main/java/com/github/mylibrelab/ui/component/AppComponent.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/AppComponent.java
@@ -32,7 +32,7 @@ import com.github.weisj.darklaf.util.Alignment;
 
 /**
  * A pluggable component which corresponds to a tab in the application frame. Classes implementing
- * {@link AppComponent} should be annotated with {@code @AutoService(AppComponent.class)}
+ * {@link AppComponent} should be annotated with {@code @Service(AppComponent.class)}
  */
 public interface AppComponent {
 

--- a/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyA.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyA.java
@@ -20,11 +20,11 @@
 
 package com.github.mylibrelab.ui.component.dummy;
 
+import com.github.mylibrelab.annotations.Service;
 import com.github.mylibrelab.ui.component.AppComponent;
 import com.github.weisj.darklaf.util.Alignment;
-import com.google.auto.service.AutoService;
 
-@AutoService(AppComponent.class)
+@Service(AppComponent.class)
 public class DummyA extends DummyComponent {
 
     public DummyA() {

--- a/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyC.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyC.java
@@ -20,11 +20,11 @@
 
 package com.github.mylibrelab.ui.component.dummy;
 
+import com.github.mylibrelab.annotations.Service;
 import com.github.mylibrelab.ui.component.AppComponent;
 import com.github.weisj.darklaf.util.Alignment;
-import com.google.auto.service.AutoService;
 
-@AutoService(AppComponent.class)
+@Service(AppComponent.class)
 public class DummyC extends DummyComponent {
 
     public DummyC() {

--- a/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyD.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyD.java
@@ -20,11 +20,11 @@
 
 package com.github.mylibrelab.ui.component.dummy;
 
+import com.github.mylibrelab.annotations.Service;
 import com.github.mylibrelab.ui.component.AppComponent;
 import com.github.weisj.darklaf.util.Alignment;
-import com.google.auto.service.AutoService;
 
-@AutoService(AppComponent.class)
+@Service(AppComponent.class)
 public class DummyD extends DummyComponent {
 
     public DummyD() {

--- a/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyE.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyE.java
@@ -20,11 +20,11 @@
 
 package com.github.mylibrelab.ui.component.dummy;
 
+import com.github.mylibrelab.annotations.Service;
 import com.github.mylibrelab.ui.component.AppComponent;
 import com.github.weisj.darklaf.util.Alignment;
-import com.google.auto.service.AutoService;
 
-@AutoService(AppComponent.class)
+@Service(AppComponent.class)
 public class DummyE extends DummyComponent {
 
     public DummyE() {

--- a/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyF.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyF.java
@@ -20,11 +20,11 @@
 
 package com.github.mylibrelab.ui.component.dummy;
 
+import com.github.mylibrelab.annotations.Service;
 import com.github.mylibrelab.ui.component.AppComponent;
 import com.github.weisj.darklaf.util.Alignment;
-import com.google.auto.service.AutoService;
 
-@AutoService(AppComponent.class)
+@Service(AppComponent.class)
 public class DummyF extends DummyComponent {
 
     public DummyF() {

--- a/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyG.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyG.java
@@ -20,11 +20,11 @@
 
 package com.github.mylibrelab.ui.component.dummy;
 
+import com.github.mylibrelab.annotations.Service;
 import com.github.mylibrelab.ui.component.AppComponent;
 import com.github.weisj.darklaf.util.Alignment;
-import com.google.auto.service.AutoService;
 
-@AutoService(AppComponent.class)
+@Service(AppComponent.class)
 public class DummyG extends DummyComponent {
 
     public DummyG() {

--- a/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyH.java
+++ b/src/main/java/com/github/mylibrelab/ui/component/dummy/DummyH.java
@@ -20,11 +20,11 @@
 
 package com.github.mylibrelab.ui.component.dummy;
 
+import com.github.mylibrelab.annotations.Service;
 import com.github.mylibrelab.ui.component.AppComponent;
 import com.github.weisj.darklaf.util.Alignment;
-import com.google.auto.service.AutoService;
 
-@AutoService(AppComponent.class)
+@Service(AppComponent.class)
 public class DummyH extends DummyComponent {
 
     public DummyH() {

--- a/src/main/kotlin/com/github/mylibrelab/settings/GuiStateSettings.kt
+++ b/src/main/kotlin/com/github/mylibrelab/settings/GuiStateSettings.kt
@@ -20,6 +20,7 @@
 
 package com.github.mylibrelab.settings
 
+import com.github.mylibrelab.annotations.Service
 import com.github.mylibrelab.lifecycle.AppLifecycleAdapter
 import com.github.mylibrelab.lifecycle.AppLifecycleListener
 import com.github.mylibrelab.settings.api.*
@@ -28,9 +29,8 @@ import com.github.mylibrelab.ui.persistent.PersistenceNode
 import com.github.mylibrelab.util.andThen
 import com.github.mylibrelab.util.propertyParser
 import com.github.mylibrelab.util.transformerOf
-import com.google.auto.service.AutoService
 
-@AutoService(AppLifecycleListener::class)
+@Service(AppLifecycleListener::class)
 internal class GuiStateAppLifecycleListener : AppLifecycleAdapter() {
 
     override fun appFrameCreated() {
@@ -42,7 +42,7 @@ internal class GuiStateAppLifecycleListener : AppLifecycleAdapter() {
     }
 }
 
-@AutoService(SettingsContainerProvider::class)
+@SettingsProvider
 class GuiStateSettingsProvider : SingletonSettingsContainerProvider({ GuiStateSettings })
 
 object GuiStateSettings : DefaultSettingsContainer(identifier = "gui_state") {

--- a/src/main/kotlin/com/github/mylibrelab/settings/LocaleSettings.kt
+++ b/src/main/kotlin/com/github/mylibrelab/settings/LocaleSettings.kt
@@ -23,10 +23,9 @@ package com.github.mylibrelab.settings
 import com.github.mylibrelab.settings.api.*
 import com.github.mylibrelab.util.transformerOf
 import com.github.weisj.darklaf.LafManager
-import com.google.auto.service.AutoService
 import java.util.*
 
-@AutoService(SettingsContainerProvider::class)
+@SettingsProvider
 class LocaleSettingsProvider : SingletonSettingsContainerProvider({ LocaleSettings })
 
 object LocaleSettings : DefaultSettingsContainer(identifier = "locale") {
@@ -34,8 +33,8 @@ object LocaleSettings : DefaultSettingsContainer(identifier = "locale") {
     var locale: Locale = Locale.getDefault()
         set(l) {
             field = l
-            if (Locale.getDefault() != locale) {
-                Locale.setDefault(locale)
+            if (Locale.getDefault() != field) {
+                Locale.setDefault(field)
                 LafManager.install()
             }
         }

--- a/src/main/kotlin/com/github/mylibrelab/settings/Settings.kt
+++ b/src/main/kotlin/com/github/mylibrelab/settings/Settings.kt
@@ -20,20 +20,21 @@
 
 package com.github.mylibrelab.settings
 
+import com.github.mylibrelab.annotations.Service
 import com.github.mylibrelab.lifecycle.AppLifecycleAdapter
 import com.github.mylibrelab.lifecycle.AppLifecycleListener
 import com.github.mylibrelab.settings.api.SettingsStorage
-import com.google.auto.service.AutoService
 
-@AutoService(AppLifecycleListener::class)
+@Service(AppLifecycleListener::class)
 internal class SettingsAppLifecycleListener : AppLifecycleAdapter() {
 
     override fun applicationStarted() {
-        Settings.reset()
         Settings.loadState()
     }
 
-    override fun applicationStopping() = Settings.saveState()
+    override fun applicationStopping() {
+        Settings.saveState()
+    }
 }
 
 object Settings {

--- a/src/main/kotlin/com/github/mylibrelab/settings/StartupSettings.kt
+++ b/src/main/kotlin/com/github/mylibrelab/settings/StartupSettings.kt
@@ -21,9 +21,8 @@
 package com.github.mylibrelab.settings
 
 import com.github.mylibrelab.settings.api.*
-import com.google.auto.service.AutoService
 
-@AutoService(SettingsContainerProvider::class)
+@SettingsProvider
 class StartupSettingsProvider : SingletonSettingsContainerProvider({ StartupSettings })
 
 object StartupSettings : DefaultSettingsContainer(identifier = "startup") {

--- a/src/main/kotlin/com/github/mylibrelab/settings/ThemeSettings.kt
+++ b/src/main/kotlin/com/github/mylibrelab/settings/ThemeSettings.kt
@@ -27,10 +27,9 @@ import com.github.weisj.darklaf.LafManager
 import com.github.weisj.darklaf.theme.Theme
 import com.github.weisj.darklaf.theme.info.AccentColorRule
 import com.github.weisj.darklaf.theme.info.FontSizeRule
-import com.google.auto.service.AutoService
 import java.awt.Color
 
-@AutoService(SettingsContainerProvider::class)
+@SettingsProvider
 class ThemeSettingsProvider : SingletonSettingsContainerProvider({ ThemeSettings })
 
 /*


### PR DESCRIPTION
**Note** This PR also includes the changes from #81 

This PR replaces the usage of `@AutoService` with a custom annotations processor which is more flexible for our use case.

Currently all services need to be annotated using `@AutoService(<service class>)` which is often not very conceptual.
Also for the sake of decoupling views from models the current ServiceLoader api doesn't provide the option to have any generic constraints.

The first problem is solved by providing the `@ServiceSpec(<service class>)` meta annotation,
which can be used to create new service annotations, where the annotated have to be assignable to the given <service class>.
For general single-use service declaration the @service(<service class>) annotation replaces `@AutoService(<service class>)`.

The second problem is solved by providing the `@ProviderSpec(inputBound, outputBound)` meta annotation which can
be used to create provider annotations. Classes annotated with @ProviderSpec need to implement the `ProviderFor<A, B>` interface,
such that `A` is assignable from inputBound and B is assignable to outputBound.
These types are checked when requesting the provided value. Request are fulfilled in the following manner:

**Note** that `A` and `B` are treated throughout as if type erasure had been applied.

For an object a of type `A` which request an object of type `B` a provider which is "assignable" to `ProviderFor<? super A, ? extend B>`.
("assignable" in quotes because java won't actually let one assign one to the other, but assignable is meant in the way that the following is legal:
````java
ProviderFor<? super A, ? extends B> provider = ...
A a = ...
B b = provider.provide(a);
````
).
If there are multiple candidates which match, then the provider with the most specific inout and the least specific output type is used.
i.e. if there are type `C < B < A` (where `<` means "is subtype of"), and `P<T, K> := ProviderFor<T, K>` then
- requesting `P<C, A>` with` P<A, A>`, `P<B, A>` and `P<C, A>` available will result in `P<C, A>` being selected.
- requesting `P<A, A>` with `P<A, A>`, `P<A, B>` and `P<A, C>` available will result in `P<C, A>` being selected.
If there are multiple providers which fulfill the requested specification which cannot be compared
(e.g. `P<A1, B>`,` P<A2, B>` where `A1` and `A2` both are subtypes of `A` but neither is a subtype of the other) then a warning is issued and no guarantee is given
on which provider will be used.

There also is a general `@Provider` annotation which imposes no bounds on the input and output type.

In contrast to AutoService the used approach is one of an isolating annotation processor which allows for better incremental compilation.

The `ServiceManager` is responsible for handling provider/service requests and uses the `ServiceLoader` internally.